### PR TITLE
style: rename main file of MedicalAppointmentApplication to Application

### DIFF
--- a/src/main/java/tech/janio/medical_appointments/Application.java
+++ b/src/main/java/tech/janio/medical_appointments/Application.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class MedicalAppointmentsApplication {
+public class Application {
 
 	public static void main(String[] args) {
-		SpringApplication.run(MedicalAppointmentsApplication.class, args);
+		SpringApplication.run(Application.class, args);
 	}
 
 }


### PR DESCRIPTION
## ✨ O que foi feito

- Renomeada a classe `MedicalAppointmentsApplication` para `Application`
- Ajustada a assinatura da classe para refletir o novo nome
- Atualizado o nome do arquivo de `MedicalAppointmentsApplication` para `Application`

## 📌 Motivação

- Tornar o nome da classe principal mais genérico e adequado a padrões comuns em projetos com múltiplos módulos ou contextos
- Melhorar a legibilidade e clareza no ponto de entrada da aplicação Spring Boot

## ✅ Checklist

- [x] Aplicação compila e executa normalmente
- [x] Classe principal continua anotada com `@SpringBootApplication`
- [x] Estrutura de pacotes permanece correta
- [x] Component scan não foi afetado

